### PR TITLE
feat : Board Update 기능 추가 및 api에 맞는 변수명으로 변경, CRUD 틀 작업

### DIFF
--- a/src/main/java/com/pokemon/newsfeed/controller/BoardController.java
+++ b/src/main/java/com/pokemon/newsfeed/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.pokemon.newsfeed.controller;
 
+import com.pokemon.newsfeed.dto.requestDto.BoardDeleteDto;
 import com.pokemon.newsfeed.dto.requestDto.BoardUpdateDto;
 import com.pokemon.newsfeed.dto.responseDto.BoardResponseDto;
 import com.pokemon.newsfeed.entity.Board;
@@ -26,5 +27,15 @@ public class BoardController {
         BoardResponseDto boardResponseDto = new BoardResponseDto(board);
 
         return new ResponseEntity<>(boardResponseDto, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{boardnum}")
+    public ResponseEntity<String> deleteBoard(
+            @PathVariable Long boardnum,
+            @RequestBody BoardDeleteDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        boardService.deleteBoard(boardnum, requestDto, userDetails.getUser());
+        return ResponseEntity.ok("삭제 완료");
     }
 }

--- a/src/main/java/com/pokemon/newsfeed/controller/BoardController.java
+++ b/src/main/java/com/pokemon/newsfeed/controller/BoardController.java
@@ -1,4 +1,30 @@
 package com.pokemon.newsfeed.controller;
 
+import com.pokemon.newsfeed.dto.requestDto.BoardUpdateDto;
+import com.pokemon.newsfeed.dto.responseDto.BoardResponseDto;
+import com.pokemon.newsfeed.entity.Board;
+import com.pokemon.newsfeed.security.UserDetailsImpl;
+import com.pokemon.newsfeed.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/boards")
 public class BoardController {
+    private final BoardService boardService;
+
+    @PutMapping("/{boardnum}")
+    public ResponseEntity<BoardResponseDto> updateBoard(
+            @PathVariable Long boardnum,
+            @RequestBody BoardUpdateDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Board board = boardService.updateBoard(boardnum, requestDto, userDetails.getUser());
+        BoardResponseDto boardResponseDto = new BoardResponseDto(board);
+
+        return new ResponseEntity<>(boardResponseDto, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/pokemon/newsfeed/dto/requestDto/BoardDeleteDto.java
+++ b/src/main/java/com/pokemon/newsfeed/dto/requestDto/BoardDeleteDto.java
@@ -1,0 +1,13 @@
+package com.pokemon.newsfeed.dto.requestDto;
+
+import lombok.*;
+
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+public class BoardDeleteDto {
+    private String title;
+    private String contents;
+}

--- a/src/main/java/com/pokemon/newsfeed/dto/requestDto/BoardUpdateDto.java
+++ b/src/main/java/com/pokemon/newsfeed/dto/requestDto/BoardUpdateDto.java
@@ -3,11 +3,11 @@ package com.pokemon.newsfeed.dto.requestDto;
 import lombok.*;
 
 @ToString
-@Setter
-@Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardRequestDto {
+@Setter
+@Getter
+public class BoardUpdateDto {
     private String title;
     private String contents;
 }

--- a/src/main/java/com/pokemon/newsfeed/dto/responseDto/BoardResponseDto.java
+++ b/src/main/java/com/pokemon/newsfeed/dto/responseDto/BoardResponseDto.java
@@ -1,4 +1,30 @@
 package com.pokemon.newsfeed.dto.responseDto;
 
+import com.pokemon.newsfeed.entity.Board;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Setter
+@Getter
 public class BoardResponseDto {
+    private Long boardNum;
+    private String title;
+    private String contents;
+    private String userId;
+    private LocalDateTime createAt;
+    private LocalDateTime modifiedAt;
+
+    public BoardResponseDto(Board board) {
+        this.boardNum = board.getBoardNum();
+        this.title = board.getTitle();
+        this.contents = board.getContents();
+        this.userId = board.getUser().getUserId();
+        this.createAt = board.getCreatedAt();
+        this.modifiedAt = board.getModifiedAt();
+
+    }
 }

--- a/src/main/java/com/pokemon/newsfeed/entity/Board.java
+++ b/src/main/java/com/pokemon/newsfeed/entity/Board.java
@@ -1,6 +1,5 @@
 package com.pokemon.newsfeed.entity;
 
-import com.pokemon.newsfeed.dto.requestDto.BoardRequestDto;
 import com.pokemon.newsfeed.dto.requestDto.BoardUpdateDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/pokemon/newsfeed/entity/Board.java
+++ b/src/main/java/com/pokemon/newsfeed/entity/Board.java
@@ -1,6 +1,9 @@
 package com.pokemon.newsfeed.entity;
 
+import com.pokemon.newsfeed.dto.requestDto.BoardRequestDto;
+import com.pokemon.newsfeed.dto.requestDto.BoardUpdateDto;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,15 +11,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity
 @Table(name = "boards")
+@AllArgsConstructor
 public class Board extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long boardSeq;
+    private Long boardNum;
     @Column(nullable = false, length = 50)
     private String title;
     @Lob // 대용량 데이터 저장 시 사용
-    private String content;
+    private String contents;
     @ManyToOne // 다대일 매핑 : 한명의 유저는 여러개의 게시글을 쓸 수 있다.
-    @JoinColumn(name = "userSeq") // foreign key : userSeq, references User : id
+    @JoinColumn(name = "userNum", nullable = false) // foreign key : userSeq, references User : id
     private User user; // DB는 오브젝트를 저장할 수 없다. FK, 자바는 오브젝트를 저장할 수 있다. // 참조할 데이터
+
+    public void updateBoard(BoardUpdateDto requestDto) {
+        this.title = requestDto.getTitle();
+        this.contents = requestDto.getContents();
+    }
 }

--- a/src/main/java/com/pokemon/newsfeed/entity/User.java
+++ b/src/main/java/com/pokemon/newsfeed/entity/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Getter
 @Entity
 @Table(name = "users")
@@ -11,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class User extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userSeq;
+    private Long userNum;
     @Column(nullable = false, unique = true, length = 50)
     private String userId;
     @Column(nullable = false)
@@ -30,5 +32,12 @@ public class User extends Timestamped {
         this.email = email;
         this.name = name;
         this.role = role;
+    }
+
+    @Override
+    public boolean equals(Object o) {  //user 객체의 num 과 userid 속성이 같은 경우에만 두 객체를 동등하다고 판단하는 로직
+        if (this == o) return true;
+        if (!(o instanceof User user)) return false;
+        return Objects.equals(getUserNum(), user.getUserNum()) && Objects.equals(getUserId(), user.getUserId());
     }
 }

--- a/src/main/java/com/pokemon/newsfeed/repository/BoardRepository.java
+++ b/src/main/java/com/pokemon/newsfeed/repository/BoardRepository.java
@@ -1,4 +1,12 @@
 package com.pokemon.newsfeed.repository;
 
-public interface BoardRepository {
+import com.pokemon.newsfeed.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+   List<Board> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/pokemon/newsfeed/security/UserDetailsImpl.java
+++ b/src/main/java/com/pokemon/newsfeed/security/UserDetailsImpl.java
@@ -5,7 +5,6 @@ import com.pokemon.newsfeed.entity.UserRoleEnum;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.yaml.snakeyaml.external.com.google.gdata.util.common.base.UnicodeEscaper;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/com/pokemon/newsfeed/security/UserDetailsImpl.java
+++ b/src/main/java/com/pokemon/newsfeed/security/UserDetailsImpl.java
@@ -18,6 +18,9 @@ public class UserDetailsImpl implements UserDetails {
         this.user = user;
     }
     // User 객체 생성 후 생성자를 통해 이 객체를 받아서 멤버 변수로 사용
+    public User getUser() {
+        return user;
+    }
 
     @Override
     public String getUsername() {

--- a/src/main/java/com/pokemon/newsfeed/service/BoardService.java
+++ b/src/main/java/com/pokemon/newsfeed/service/BoardService.java
@@ -4,7 +4,6 @@ import com.pokemon.newsfeed.dto.requestDto.BoardUpdateDto;
 import com.pokemon.newsfeed.entity.Board;
 import com.pokemon.newsfeed.entity.User;
 import com.pokemon.newsfeed.repository.BoardRepository;
-import com.pokemon.newsfeed.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/pokemon/newsfeed/service/BoardService.java
+++ b/src/main/java/com/pokemon/newsfeed/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.pokemon.newsfeed.service;
 
+import com.pokemon.newsfeed.dto.requestDto.BoardDeleteDto;
 import com.pokemon.newsfeed.dto.requestDto.BoardUpdateDto;
 import com.pokemon.newsfeed.entity.Board;
 import com.pokemon.newsfeed.entity.User;
@@ -16,15 +17,25 @@ public class BoardService {
     @Transactional
     public Board updateBoard(Long boardNum, BoardUpdateDto requestDto, User user) {
         Board board = findOne(boardNum);
-        if(!board.getUser().equals(user)) {
+        if (!board.getUser().equals(user)) {
             throw new IllegalArgumentException("작성자만 삭제/수정할 수 있습니다.");
         }
-            board.updateBoard(requestDto);
-            return board;
+        board.updateBoard(requestDto);
+        return board;
+    }
+
+    public void deleteBoard(Long boardnum, BoardDeleteDto requestDto, User user) {
+        Board board = findOne(boardnum);
+
+        if (!board.getUser().equals(user)) {
+            throw new IllegalArgumentException("작성자만 삭제/수정할 수 있습니다.");
         }
+        boardRepository.delete(board);
+    }
 
 
     private Board findOne(Long boardNum) {
         return boardRepository.findById(boardNum).orElseThrow(() -> new IllegalArgumentException("없는 게시글 입니다."));
     }
+
 }

--- a/src/main/java/com/pokemon/newsfeed/service/BoardService.java
+++ b/src/main/java/com/pokemon/newsfeed/service/BoardService.java
@@ -1,4 +1,31 @@
 package com.pokemon.newsfeed.service;
 
+import com.pokemon.newsfeed.dto.requestDto.BoardUpdateDto;
+import com.pokemon.newsfeed.entity.Board;
+import com.pokemon.newsfeed.entity.User;
+import com.pokemon.newsfeed.repository.BoardRepository;
+import com.pokemon.newsfeed.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class BoardService {
+
+    private final BoardRepository boardRepository;
+    @Transactional
+    public Board updateBoard(Long boardNum, BoardUpdateDto requestDto, User user) {
+        Board board = findOne(boardNum);
+        if(!board.getUser().equals(user)) {
+            throw new IllegalArgumentException("작성자만 삭제/수정할 수 있습니다.");
+        }
+            board.updateBoard(requestDto);
+            return board;
+        }
+
+
+    private Board findOne(Long boardNum) {
+        return boardRepository.findById(boardNum).orElseThrow(() -> new IllegalArgumentException("없는 게시글 입니다."));
+    }
 }


### PR DESCRIPTION
🔢 update 
_**Board.java**_
AllArgsConstructor 어노테이션이 추가되었습니다.
updateBoard constructor 가 추가되었습니다.

_**BoardController.java**_
BoardController 의 전반적인 틀을 잡고, UserDetailsImpl 에서 user 정보를 가지고오는 update 기능을 추가하였습니다.

_**BoardRepository.java
BoardRequestDto.java**_
BoardRepository, BoardRequestDto.java 의 전반적인 틀을 잡았습니다.

_**BoardResponseDto.java**_
BoardResponseDto 의 전반적인 틀을 잡고, constructor 를 추가했습니다.
작성자 정보를 가져오기 위해 user 에 접근했습니다.

_**BoardService.java**_
BoardService 의 전반적인 틀을 잡고, update 로직을 추가했습니다.
작성자만 삭제/수정 할 수 있게 설정 했습니다. 그렇지 않을 시 Exception message 를 throw 합니다. 또한 잘못 된 게시글 선택 시 Exception message 를 throw 합니다.

_**User.java**_
BoardService.java 의 update 로직에서 유저 검증을 위한 equals 로직이 추가되었습니다.

_**UserDetailsImpl.java**_
BoardController 의 update 에서 외부에서 들어오는 user 정보의 접근을 위해 getUser 메서드가 추가되었습니다.

🔢 add 
_**BoardUpdateDto.java**_
BoardUpdateDto 의 전반적인 틀을 잡았습니다.

이 외에 userSeq -> userNum, boardSeq -> boardNum (Entity 부분) 과 같은 변경이 있었습니다.


**+추가**
delete 기능구현이 추가되었습니다.
🔢 update : 
_**BoardController.java**_
delete 기능이 추가되었습니다.

_**BoardService.java**_
delete 기능을 위한 비즈니스 로직이 추가되었습니다. (update 기능과 같은 user entity에 있는 로직을 사용했습니다.)

🔢 add : 
_**BoardDeleteDto.java**_
BoardDeleteDto 의 전반적인 틀을 잡았습니다.